### PR TITLE
[FIX] lobby waiting players with demo

### DIFF
--- a/Client/src/GameTypes.cpp
+++ b/Client/src/GameTypes.cpp
@@ -21,7 +21,8 @@
 using boost::asio::ip::udp;
 
 GameManager::GameManager(sf::Vector2u windowSize)
-    : launch(windowSize), parameters(windowSize), controlsConfig(windowSize), lobby(windowSize), errorServer(windowSize), player(windowSize), waitingPlayersCounter(1),
+    : launch(windowSize), parameters(windowSize), controlsConfig(windowSize), lobby(windowSize), errorServer(windowSize), player(windowSize),
+      waitingPlayersCounter(1),
       gameMode(GameMode::SOLO),
       particleSystem(windowSize, 300),
       currentState(State::LAUNCH),
@@ -215,6 +216,10 @@ void GameManager::update()
     } else if (currentState == State::LOCKER) {
         player.update();
     } else if (currentState == State::LOBBY) {
+        if ((waitingPlayersCounter == 1 && gameMode == GameMode::SOLO) || (waitingPlayersCounter == 2 && gameMode == GameMode::DUO) ||
+            (waitingPlayersCounter == 3 && gameMode == GameMode::TRIO) || (waitingPlayersCounter == 4 && gameMode == GameMode::SQUAD)) {
+            currentState = State::GAME;
+        }
         player.update();
     } else if (currentState == State::ERRORSERVER) {
         errorServer.update();
@@ -325,6 +330,7 @@ void GameManager::handleMouseClick(sf::Event& event, sf::RenderWindow& window) {
     if (event.mouseButton.button != sf::Mouse::Left) return;
 
     sf::Vector2i mousePos = sf::Mouse::getPosition(window);
+
     if (currentState == State::LAUNCH) {
         if (connectToServer("127.0.0.1", 8080)) {
             statusText.setString("Connected to the server !");


### PR DESCRIPTION
This pull request updates the game state transition logic in the `GameManager` class, primarily to improve how the game moves from the lobby to the gameplay state based on the selected game mode and the number of waiting players.

**Gameplay state transition improvements:**

* Added logic to automatically transition from `LOBBY` to `GAME` state when the correct number of players have joined, depending on the selected `gameMode` (SOLO, DUO, TRIO, SQUAD).

**Code formatting and readability:**

* Reformatted the member initializer list in the `GameManager` constructor for better readability.
* Minor formatting adjustment in the `handleMouseClick` method for code clarity.