### PR TITLE
[FIX] Locker change starship

### DIFF
--- a/Client/src/GameTypes.cpp
+++ b/Client/src/GameTypes.cpp
@@ -436,7 +436,7 @@ void GameManager::handleMouseClick(sf::Event& event, sf::RenderWindow& window) {
             player.starshipSprite.setTextureRect(player.starshipRect);
         }
         if (rightButtonSelection.isClicked(mousePos)) {
-            int maxTop = 17 * 5;
+            int maxTop = 17 * 4;
             int newTop = player.starshipRect.top + 17;
             if (newTop > maxTop)
                 newTop = maxTop;


### PR DESCRIPTION
This pull request makes a small adjustment to the logic for handling mouse clicks in the game. The change reduces the maximum allowed value for the `starshipRect.top` property when the right button is clicked, which likely restricts the sprite selection or movement.

* Reduced the maximum allowed value for `player.starshipRect.top` from `17 * 5` to `17 * 4` in the `handleMouseClick` method of `GameTypes.cpp`, affecting how far the starship sprite can move or be selected.