### PR TITLE
[FIX] Mode off when you click a second time on him

### DIFF
--- a/Client/src/GameTypes.cpp
+++ b/Client/src/GameTypes.cpp
@@ -358,7 +358,10 @@ void GameManager::handleMouseClick(sf::Event& event, sf::RenderWindow& window) {
             numberPlayerToWait.setString("Waiting players: " + std::to_string(getWaitingPlayersCount()) + "/4");
         }
         if (modeButton.isClicked(mousePos)) {
-            isChooseMode = true;
+            if (isChooseMode)
+                isChooseMode = false;
+            else
+                isChooseMode = true;
         } else {
             isChooseMode = false;
         }


### PR DESCRIPTION
This pull request introduces a small improvement to the logic for toggling the game mode selection. The change simplifies the toggling of the `isChooseMode` state when the mode button is clicked.

- Improved toggle logic for `isChooseMode` in the `handleMouseClick` method of `GameTypes.cpp`, making the state switch more explicit and readable.