### PR TITLE
Dev/server room

### DIFF
--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -10,7 +10,7 @@ include_directories(../include_common)
 
 include_directories(include)
 
-file(GLOB SOURCES src/*.cpp)
+file(GLOB SOURCES src/*.cpp src/net/*.cpp)
 
 include(../cmake/CPM.cmake)
 

--- a/Client/include/net/NetworkClient.hpp
+++ b/Client/include/net/NetworkClient.hpp
@@ -1,0 +1,88 @@
+/*
+** EPITECH PROJECT, 2025
+** G-CPP-500-BDX-5-1-rtype-1
+** File description:
+** NetworkClient
+*/
+
+#ifndef NETWORKCLIENT_HPP_
+#define NETWORKCLIENT_HPP_
+
+#include <boost/asio.hpp>
+#include <memory>
+#include <string>
+#include <functional>
+#include <thread>
+#include <atomic>
+#include <queue>
+#include <mutex>
+#include "Protocol.hpp"
+
+using boost::asio::ip::udp;
+using namespace RtypeServer;
+
+class NetworkClient {
+    public:
+        using ConnectedCallback = std::function<void(uint32_t playerId)>;
+        using RoomCreatedCallback = std::function<void(const RoomCreatedBody&)>;
+        using RoomJoinedCallback = std::function<void(const RoomJoinedBody&)>;
+        using RoomLeftCallback = std::function<void(const RoomLeftBody&)>;
+        using RoomListCallback = std::function<void(const RoomListBody&)>;
+        using RoomMessageCallback = std::function<void(const RoomMessageBody&)>;
+        using RoomErrorCallback = std::function<void(const RoomErrorBody&)>;
+
+        NetworkClient();
+        ~NetworkClient();
+
+        bool connect(const std::string& serverIP, uint16_t port, const std::string& playerName);
+        void disconnect();
+        bool isConnected() const { return m_connected; }
+        
+        void createRoom(const std::string& roomName, uint8_t maxPlayers = 4);
+        void joinRoom(const std::string& roomName);
+        void leaveRoom();
+        void listRooms();
+        void sendMessage(const std::string& message);
+        
+        void setConnectedCallback(ConnectedCallback cb) { m_onConnected = cb; }
+        void setRoomCreatedCallback(RoomCreatedCallback cb) { m_onRoomCreated = cb; }
+        void setRoomJoinedCallback(RoomJoinedCallback cb) { m_onRoomJoined = cb; }
+        void setRoomLeftCallback(RoomLeftCallback cb) { m_onRoomLeft = cb; }
+        void setRoomListCallback(RoomListCallback cb) { m_onRoomList = cb; }
+        void setRoomMessageCallback(RoomMessageCallback cb) { m_onRoomMessage = cb; }
+        void setRoomErrorCallback(RoomErrorCallback cb) { m_onRoomError = cb; }
+
+        uint32_t getPlayerId() const { return m_playerId; }
+        const std::string& getPlayerName() const { return m_playerName; }
+
+    private:
+        void networkThread();
+        void startReceive();
+        void handleReceive(const boost::system::error_code& error, std::size_t bytes);
+        void sendPacket(const std::vector<uint8_t>& data);
+        
+        void processMessage(const uint8_t* data, std::size_t size);
+        
+        std::unique_ptr<boost::asio::io_context> m_io;
+        std::unique_ptr<udp::socket> m_socket;
+        udp::endpoint m_serverEndpoint;
+        std::array<uint8_t, 1500> m_rxBuffer;
+        Protocol m_protocol;
+        
+        std::atomic<bool> m_connected{false};
+        std::atomic<bool> m_running{false};
+        std::unique_ptr<std::thread> m_networkThread;
+        
+        uint32_t m_playerId = 0;
+        std::string m_playerName;
+        
+        ConnectedCallback m_onConnected;
+        RoomCreatedCallback m_onRoomCreated;
+        RoomJoinedCallback m_onRoomJoined;
+        RoomLeftCallback m_onRoomLeft;
+        RoomListCallback m_onRoomList;
+        RoomMessageCallback m_onRoomMessage;
+        RoomErrorCallback m_onRoomError;
+};
+
+#endif /* !NETWORKCLIENT_HPP_ */

--- a/Client/include/net/Protocol.hpp
+++ b/Client/include/net/Protocol.hpp
@@ -1,0 +1,158 @@
+/*
+** EPITECH PROJECT, 2025
+** G-CPP-500-BDX-5-1-rtype-1
+** File description:
+** Protocol
+*/
+
+#ifndef PROTOCOL_HPP_
+#define PROTOCOL_HPP_
+
+
+#pragma once
+#include <cstdint>
+#include <cstddef>
+#include <vector>
+#include <string>
+
+#define kMagic 0xCAFE
+#define kProtoVersion 1
+
+namespace RtypeServer {
+    
+    struct NetHeader {
+        uint16_t magic;
+        uint8_t  version;
+        uint8_t  type;
+        uint32_t seq;
+        uint32_t ack;
+        uint32_t ackBits;
+    };
+
+    enum class MsgType : uint8_t {
+        HELLO = 1,
+        WELCOME = 2,
+        PING = 3,
+        PONG = 4,
+        INPUT = 10,
+        SNAPSHOT = 11,
+        EVENT = 12,
+
+        CREATE_ROOM = 20,
+        JOIN_ROOM = 21,
+        LEAVE_ROOM = 22,
+        LIST_ROOMS = 23,
+        MESSAGE = 24,
+
+        ROOM_CREATED = 30,
+        ROOM_JOINED  = 31,
+        ROOM_LEFT = 32,
+        ROOM_LIST = 33,
+        ROOM_MESSAGE = 34,
+        ROOM_ERROR = 35,
+    };
+
+    struct HelloBody {
+        uint32_t client_nonce = 0;
+        uint8_t  proto = kProtoVersion;
+        std::string name;
+    };
+    
+    struct WelcomeBody {
+        uint32_t playerId = 0;
+        uint16_t roomId = 0;
+        uint32_t baselineTick = 0;
+    };
+    struct CreateRoomBody {
+        std::string roomName;
+        uint8_t maxPlayers = 4;
+    };
+
+    struct JoinRoomBody {
+        std::string roomName;
+    };
+
+    struct MessageBody {
+        std::string message;
+    };
+    struct RoomCreatedBody {
+        uint32_t roomId = 0;
+        std::string roomName;
+        uint8_t success = 1;
+    };
+    struct RoomJoinedBody {
+        uint32_t roomId = 0;
+        std::string roomName;
+        uint8_t success = 1;
+        uint8_t playerCount = 0;
+    };
+    struct RoomLeftBody {
+        uint32_t roomId = 0;
+        uint8_t success = 1;
+    };
+    struct RoomInfoEntry {
+        uint32_t roomId = 0;
+        std::string roomName;
+        uint8_t currentPlayers = 0;
+        uint8_t maxPlayers = 0;
+    };
+    struct RoomListBody {
+        std::vector<RoomInfoEntry> rooms;
+    };
+    struct RoomMessageBody {
+        uint32_t senderId = 0;
+        std::string senderName;
+        std::string message;
+    };
+    struct RoomErrorBody {
+        uint8_t errorCode = 0;
+        std::string errorMessage;
+    };
+
+    class Protocol {
+        public:
+            Protocol();
+            ~Protocol();
+            void writeHeader(std::vector<uint8_t>& out, const NetHeader& h);
+            NetHeader readHeader(const uint8_t* data, std::size_t size);
+            void append_u8 (std::vector<uint8_t>& out, uint8_t v);
+            void append_u16be(std::vector<uint8_t>& out, uint16_t v);
+            void append_u32be(std::vector<uint8_t>& out, uint32_t v);
+            void append_i16be(std::vector<uint8_t>& out, int16_t v);
+
+            uint8_t  read_u8 (const uint8_t* data, std::size_t& off, std::size_t size);
+            uint16_t read_u16be(const uint8_t* data, std::size_t& off, std::size_t size);
+            uint32_t read_u32be(const uint8_t* data, std::size_t& off, std::size_t size);
+            int16_t  read_i16be(const uint8_t* data, std::size_t& off, std::size_t size);
+            void writeHelloBody  (std::vector<uint8_t>& out, const HelloBody& b);
+            HelloBody readHelloBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeWelcomeBody(std::vector<uint8_t>& out, const WelcomeBody& b);
+            WelcomeBody readWelcomeBody(const uint8_t* data, std::size_t size, std::size_t& off);
+    
+            void writeCreateRoomBody(std::vector<uint8_t>& out, const CreateRoomBody& b);
+            CreateRoomBody readCreateRoomBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeJoinRoomBody(std::vector<uint8_t>& out, const JoinRoomBody& b);
+            JoinRoomBody readJoinRoomBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeMessageBody(std::vector<uint8_t>& out, const MessageBody& b);
+            MessageBody readMessageBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeRoomCreatedBody(std::vector<uint8_t>& out, const RoomCreatedBody& b);
+            RoomCreatedBody readRoomCreatedBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeRoomJoinedBody(std::vector<uint8_t>& out, const RoomJoinedBody& b);
+            RoomJoinedBody readRoomJoinedBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeRoomLeftBody(std::vector<uint8_t>& out, const RoomLeftBody& b);
+            RoomLeftBody readRoomLeftBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeRoomListBody(std::vector<uint8_t>& out, const RoomListBody& b);
+            RoomListBody readRoomListBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeRoomMessageBody(std::vector<uint8_t>& out, const RoomMessageBody& b);
+            RoomMessageBody readRoomMessageBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeRoomErrorBody(std::vector<uint8_t>& out, const RoomErrorBody& b);
+            RoomErrorBody readRoomErrorBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeString(std::vector<uint8_t>& out, const std::string& str);
+            std::string readString(const uint8_t* data, std::size_t size, std::size_t& off);
+
+        protected:
+        private:
+    };
+}
+
+#endif /* !PROTOCOL_HPP_ */

--- a/Client/src/GameTypes.cpp
+++ b/Client/src/GameTypes.cpp
@@ -25,6 +25,9 @@ GameManager::GameManager(sf::Vector2u windowSize)
       waitingPlayersCounter(1),
       gameMode(GameMode::SOLO),
       particleSystem(windowSize, 300),
+      networkClient(nullptr),
+      playerName("Player"),
+      inRoom(false),
       currentState(State::LAUNCH),
       isConnected(ServerState::DEFAULT),
       isDraggingVolume(false),
@@ -273,6 +276,8 @@ void GameManager::render(sf::RenderWindow& window) {
     } else if (currentState == State::LOBBY) {
         player.draw(window);
         window.draw(numberPlayerToWait);
+    } else if (currentState == State::ROOM_LIST) {
+    } else if (currentState == State::IN_ROOM) {
     } else if (currentState == State::LOCKER) {
         player.draw(window);
         leftButtonSelection.draw(window);
@@ -334,16 +339,12 @@ void GameManager::handleMouseClick(sf::Event& event, sf::RenderWindow& window) {
     sf::Vector2i mousePos = sf::Mouse::getPosition(window);
 
     if (currentState == State::LAUNCH) {
-        if (connectToServer("127.0.0.1", 8080)) {
-            statusText.setString("Connected to the server !");
-            statusText.setFillColor(sf::Color::Green);
-            isConnected = ServerState::CONNECT;
+        sf::FloatRect coinBounds = insertCoinText.getGlobalBounds();
+        if (coinBounds.contains(static_cast<float>(mousePos.x), static_cast<float>(mousePos.y))) {
             currentState = State::MENU;
-        } else {
-            statusText.setString("Connection failed");
-            statusText.setFillColor(sf::Color::Red);
-            isConnected = ServerState::DISCONNECT;
-            currentState = State::ERRORSERVER;
+            updateStatusTextPosition(false);
+            statusText.setString("");
+            statusText.setFillColor(sf::Color::Yellow);
         }
     } else if (currentState == State::MENU) {
         if (soloButton.isClicked(mousePos)) {
@@ -375,10 +376,35 @@ void GameManager::handleMouseClick(sf::Event& event, sf::RenderWindow& window) {
             statusText.setString("");
         }
         if (playButton.isClicked(mousePos)) {
+            std::string roomName;
+            uint8_t maxPlayers = 1;
+            if (gameMode == GameMode::DUO) {
+                roomName = "DuoRoom";
+                maxPlayers = 2;
+            } else if (gameMode == GameMode::TRIO) {
+                roomName = "TrioRoom";
+                maxPlayers = 3;
+            } else if (gameMode == GameMode::SQUAD) {
+                roomName = "SquadRoom";
+                maxPlayers = 4;
+            }
+            if (maxPlayers > 1) {
+                if (!networkClient) {
+                    initializeNetworking("Player");
+                    connectToServerWithRooms("127.0.0.1", 8080);
+                }
+                this->waitingRoomAction = true;
+                this->waitingRoomName = roomName;
+                this->waitingRoomMaxPlayers = maxPlayers;
+                refreshRoomList();
+            }
             currentState = State::LOBBY;
             updateStatusTextPosition(true);
             statusText.setString("");
         }
+    bool waitingRoomAction = false;
+    std::string waitingRoomName;
+    uint8_t waitingRoomMaxPlayers = 1;
     } else if (currentState == State::SETTINGS) {
         if (backButton.isClicked(mousePos)) {
             if (isConnected == ServerState::CONNECT) {
@@ -446,6 +472,14 @@ void GameManager::handleMouseClick(sf::Event& event, sf::RenderWindow& window) {
             player.starshipSprite.setTextureRect(player.starshipRect);
         }
     } else if (currentState == State::LOBBY) {
+    } else if (currentState == State::ROOM_LIST) {
+        float yStart = 150;
+        int roomIndex = (mousePos.y - yStart) / 30;
+        if (roomIndex >= 0 && roomIndex < (int)availableRooms.size()) {
+            const auto& room = availableRooms[roomIndex];
+            joinRoom(room.roomName);
+        }
+    } else if (currentState == State::IN_ROOM) {
     } else if (currentState == State::ERRORSERVER) {
         if (paramButton.isClicked(mousePos)) {
             currentState = State::SETTINGS;
@@ -542,7 +576,6 @@ void GameManager::updateStatusTextPosition(bool isParametersMode)
 
 bool GameManager::connectToServer(const std::string& serverIP, unsigned short port)
 {
-    //TEMP
     return (true);
 
     try {
@@ -741,8 +774,6 @@ void GameManager::applyCurrentResolution(sf::RenderWindow& window)
 
 void GameManager::gameDemo(sf::RenderWindow &window)
 {
-    // window.setFramerateLimit(0);
-
     void *handle = dlopen("libengine.so", RTLD_LAZY);
     if (!handle) {
         std::cerr << "Failed to load libengine.so: " << dlerror() << std::endl;
@@ -756,15 +787,6 @@ void GameManager::gameDemo(sf::RenderWindow &window)
         dlclose(handle);
         return;
     }
-
-    // void (*deleteMediatorFunc)(Engine::Mediator*) = (void (*)(Engine::Mediator*))(dlsym(handle, "deleteMediator"));
-    // error = dlerror();
-    // if (error) {
-    //     std::cerr << "Cannot load symbol 'deleteMediator': " << error << std::endl;
-    //     dlclose(handle);
-    //     return (84);
-    // }
-
     std::shared_ptr<Engine::Mediator> mediator = createMediatorFunc();
     mediator->init();
 
@@ -868,3 +890,185 @@ void GameManager::gameDemo(sf::RenderWindow &window)
     }
     dlclose(handle);
 }
+
+void GameManager::initializeNetworking(const std::string& playerName)
+{
+    this->playerName = playerName;
+    networkClient = std::make_unique<NetworkClient>();
+
+    networkClient->setConnectedCallback([this](uint32_t playerId) {
+        onConnected(playerId);
+    });
+    
+    networkClient->setRoomCreatedCallback([this](const RoomCreatedBody& body) {
+        onRoomCreated(body);
+    });
+    
+    networkClient->setRoomJoinedCallback([this](const RoomJoinedBody& body) {
+        onRoomJoined(body);
+    });
+    
+    networkClient->setRoomLeftCallback([this](const RoomLeftBody& body) {
+        onRoomLeft(body);
+    });
+    
+    networkClient->setRoomListCallback([this](const RoomListBody& body) {
+        onRoomList(body);
+    });
+    
+    networkClient->setRoomMessageCallback([this](const RoomMessageBody& body) {
+        onRoomMessage(body);
+    });
+    
+    networkClient->setRoomErrorCallback([this](const RoomErrorBody& body) {
+        onRoomError(body);
+    });
+}
+
+void GameManager::connectToServerWithRooms(const std::string& serverIP, unsigned short port)
+{
+    if (!networkClient) {
+        initializeNetworking(playerName);
+    }
+    
+    if (networkClient->connect(serverIP, port, playerName)) {
+        isConnected = ServerState::CONNECT;
+        statusText.setString("Connecting to server...");
+    } else {
+        isConnected = ServerState::DISCONNECT;
+        statusText.setString("Failed to connect to server");
+        currentState = State::ERRORSERVER;
+    }
+}
+
+void GameManager::createRoom(const std::string& roomName, uint8_t maxPlayers)
+{
+    if (networkClient && networkClient->isConnected()) {
+        networkClient->createRoom(roomName, maxPlayers);
+    }
+}
+
+void GameManager::joinRoom(const std::string& roomName)
+{
+    if (networkClient && networkClient->isConnected()) {
+        networkClient->joinRoom(roomName);
+    }
+}
+
+void GameManager::leaveRoom()
+{
+    if (networkClient && networkClient->isConnected()) {
+        networkClient->leaveRoom();
+    }
+}
+
+void GameManager::refreshRoomList()
+{
+    if (networkClient && networkClient->isConnected()) {
+        networkClient->listRooms();
+    }
+}
+
+void GameManager::sendRoomMessage(const std::string& message)
+{
+    if (networkClient && networkClient->isConnected()) {
+        networkClient->sendMessage(message);
+    }
+}
+
+void GameManager::onConnected(uint32_t playerId)
+{
+    std::cout << "Connected to server! Player ID: " << playerId << std::endl;
+    isConnected = ServerState::CONNECT;
+    statusText.setString("");
+    refreshRoomList();
+}
+
+void GameManager::onRoomCreated(const RtypeServer::RoomCreatedBody& body)
+{
+    if (body.success) {
+        std::cout << "Room '" << body.roomName << "' created successfully!" << std::endl;
+        statusText.setString("");
+        currentRoomName = body.roomName;
+        inRoom = true;
+    } else {
+        std::cout << "Failed to create room '" << body.roomName << "'" << std::endl;
+        statusText.setString("Failed to create room");
+    }
+}
+
+void GameManager::onRoomJoined(const RtypeServer::RoomJoinedBody& body)
+{
+    if (body.success) {
+        std::cout << "Joined room '" << body.roomName << "' with " << (int)body.playerCount << " players" << std::endl;
+        statusText.setString("");
+        currentRoomName = body.roomName;
+        inRoom = true;
+        
+    int maxPlayers = getMaxPlayersForMode(gameMode);
+    numberPlayerToWait.setString("Waiting players: " + std::to_string(body.playerCount) + "/" + std::to_string(maxPlayers));
+        
+        refreshRoomList();
+    } else {
+        std::cout << "Failed to join room '" << body.roomName << "'" << std::endl;
+        statusText.setString("Failed to join room");
+    }
+}
+
+void GameManager::onRoomLeft(const RtypeServer::RoomLeftBody& body)
+{
+    if (body.success) {
+        std::cout << "Left room successfully" << std::endl;
+        statusText.setString("");
+        currentRoomName.clear();
+        inRoom = false;
+        
+        numberPlayerToWait.setString("Waiting players: 0/");
+        refreshRoomList();
+    } else {
+        std::cout << "Failed to leave room" << std::endl;
+        statusText.setString("Failed to leave room");
+    }
+}
+
+void GameManager::onRoomList(const RtypeServer::RoomListBody& body)
+{
+    availableRooms = body.rooms;
+    
+    if (currentState == State::LOBBY && !currentRoomName.empty()) {
+        for (const auto& r : availableRooms) {
+            if (r.roomName == currentRoomName) {
+                int maxPlayers = getMaxPlayersForMode(gameMode);
+                numberPlayerToWait.setString("Waiting players: " + std::to_string(r.currentPlayers) + "/" + std::to_string(maxPlayers));
+                break;
+            }
+        }
+    }
+    if (this->waitingRoomAction) {
+        bool found = false;
+        for (const auto& r : availableRooms) {
+            if (r.roomName == this->waitingRoomName) {
+                found = true;
+                break;
+            }
+        }
+        if (found) {
+            joinRoom(this->waitingRoomName);
+        } else {
+            createRoom(this->waitingRoomName, this->waitingRoomMaxPlayers);
+        }
+        this->waitingRoomAction = false;
+    }
+}
+
+void GameManager::onRoomMessage(const RtypeServer::RoomMessageBody& body)
+{
+    std::cout << "[Room] " << body.senderName << ": " << body.message << std::endl;
+}
+
+void GameManager::onRoomError(const RtypeServer::RoomErrorBody& body)
+{
+    std::cout << "Room error: " << body.errorMessage << std::endl;
+    statusText.setString("Error: " + body.errorMessage);
+}
+

--- a/Client/src/net/NetworkClient.cpp
+++ b/Client/src/net/NetworkClient.cpp
@@ -1,0 +1,223 @@
+/*
+/*
+** EPITECH PROJECT, 2025
+** R-TYPE
+** File description:
+/*
+** EPITECH PROJECT, 2025
+** R-TYPE
+** File description:
+** NetworkClient (client)
+*/
+
+#include "net/NetworkClient.hpp"
+#include <iostream>
+#include <thread>
+#include <mutex>
+
+using boost::asio::ip::udp;
+using namespace RtypeServer;
+
+static std::mutex s_sendMutex;
+
+NetworkClient::NetworkClient() {}
+
+NetworkClient::~NetworkClient()
+{
+    disconnect();
+}
+
+bool NetworkClient::connect(const std::string& serverIP, uint16_t port, const std::string& playerName)
+{
+    try {
+        m_io = std::make_unique<boost::asio::io_context>();
+        m_socket = std::make_unique<udp::socket>(*m_io);
+        m_serverEndpoint = udp::endpoint(boost::asio::ip::address::from_string(serverIP), port);
+        m_socket->open(udp::v4());
+        m_playerName = playerName;
+        m_running = true;
+    
+        startReceive();
+        m_networkThread = std::make_unique<std::thread>([this]() { networkThread(); });
+        std::vector<uint8_t> out;
+        NetHeader h{};
+        h.magic = kMagic;
+        h.version = kProtoVersion;
+        h.type = static_cast<uint8_t>(MsgType::HELLO);
+        m_protocol.writeHeader(out, h);
+        HelloBody hb{};
+        hb.client_nonce = 0;
+        hb.proto = kProtoVersion;
+        hb.name = m_playerName;
+        m_protocol.writeHelloBody(out, hb);
+        sendPacket(out);
+
+        m_connected = true;
+        return true;
+    } catch (const std::exception& e) {
+        std::cerr << "NetworkClient connect exception: " << e.what() << std::endl;
+        return false;
+    }
+}
+
+void NetworkClient::disconnect()
+{
+    m_running = false;
+    m_connected = false;
+    if (m_io) {
+        m_io->stop();
+    }
+    if (m_socket && m_socket->is_open()) {
+        boost::system::error_code ec;
+        m_socket->close(ec);
+    }
+    if (m_networkThread && m_networkThread->joinable())
+        m_networkThread->join();
+    m_socket.reset();
+    m_io.reset();
+    m_networkThread.reset();
+}
+
+void NetworkClient::createRoom(const std::string& roomName, uint8_t maxPlayers)
+{
+    if (!m_connected) return;
+    NetHeader h{};
+    h.magic = kMagic; h.version = kProtoVersion; h.type = static_cast<uint8_t>(MsgType::CREATE_ROOM);
+    std::vector<uint8_t> buf;
+    m_protocol.writeHeader(buf, h);
+    CreateRoomBody body{}; body.roomName = roomName; body.maxPlayers = maxPlayers;
+    m_protocol.writeCreateRoomBody(buf, body);
+    sendPacket(buf);
+}
+
+void NetworkClient::joinRoom(const std::string& roomName)
+{
+    if (!m_connected) return;
+    NetHeader h{}; h.magic = kMagic; h.version = kProtoVersion; h.type = static_cast<uint8_t>(MsgType::JOIN_ROOM);
+    std::vector<uint8_t> buf; m_protocol.writeHeader(buf, h);
+    JoinRoomBody body{}; body.roomName = roomName; m_protocol.writeJoinRoomBody(buf, body);
+    sendPacket(buf);
+}
+
+void NetworkClient::leaveRoom()
+{
+    if (!m_connected) return;
+    NetHeader h{}; h.magic = kMagic; h.version = kProtoVersion; h.type = static_cast<uint8_t>(MsgType::LEAVE_ROOM);
+    std::vector<uint8_t> buf; m_protocol.writeHeader(buf, h);
+    sendPacket(buf);
+}
+
+void NetworkClient::listRooms()
+{
+    if (!m_connected) return;
+    NetHeader h{}; h.magic = kMagic; h.version = kProtoVersion; h.type = static_cast<uint8_t>(MsgType::LIST_ROOMS);
+    std::vector<uint8_t> buf; m_protocol.writeHeader(buf, h);
+    sendPacket(buf);
+}
+
+void NetworkClient::sendMessage(const std::string& message)
+{
+    if (!m_connected) return;
+    NetHeader h{}; h.magic = kMagic; h.version = kProtoVersion; h.type = static_cast<uint8_t>(MsgType::MESSAGE);
+    std::vector<uint8_t> buf; m_protocol.writeHeader(buf, h);
+    MessageBody body{}; body.message = message; m_protocol.writeMessageBody(buf, body);
+    sendPacket(buf);
+}
+
+void NetworkClient::networkThread()
+{
+    try {
+        m_io->run();
+    } catch (const std::exception& e) {
+        std::cerr << "Network thread exception: " << e.what() << std::endl;
+    }
+}
+
+void NetworkClient::startReceive()
+{
+    if (!m_socket) return;
+    m_socket->async_receive_from(boost::asio::buffer(m_rxBuffer), m_serverEndpoint,
+        [this](const boost::system::error_code& ec, std::size_t bytes) {
+            handleReceive(ec, bytes);
+        });
+}
+
+void NetworkClient::handleReceive(const boost::system::error_code& error, std::size_t bytes)
+{
+    if (!error && bytes > 0) {
+        processMessage(m_rxBuffer.data(), bytes);
+    }
+    if (m_running) {
+        startReceive();
+    }
+}
+
+void NetworkClient::sendPacket(const std::vector<uint8_t>& data)
+{
+    if (!m_socket) return;
+    auto buf = std::make_shared<std::vector<uint8_t>>(data);
+    std::lock_guard<std::mutex> lk(s_sendMutex);
+    m_socket->async_send_to(boost::asio::buffer(*buf), m_serverEndpoint,
+        [buf](const boost::system::error_code& ec, std::size_t) {
+            if (ec) std::cerr << "sendPacket error: " << ec.message() << std::endl;
+        });
+}
+
+void NetworkClient::processMessage(const uint8_t* data, std::size_t size)
+{
+    try {
+        NetHeader h = m_protocol.readHeader(data, size);
+        if (h.magic != kMagic || h.version != kProtoVersion) {
+            std::cerr << "Bad packet received (magic/version mismatch)" << std::endl;
+            return;
+        }
+        std::size_t off = sizeof(NetHeader);
+        MsgType t = static_cast<MsgType>(h.type);
+        switch (t) {
+            case MsgType::WELCOME: {
+                WelcomeBody wb = m_protocol.readWelcomeBody(data, size, off);
+                m_playerId = wb.playerId;
+                m_connected = true;
+                if (m_onConnected) m_onConnected(m_playerId);
+                listRooms();
+                break;
+            }
+            case MsgType::ROOM_CREATED: {
+                RoomCreatedBody rb = m_protocol.readRoomCreatedBody(data, size, off);
+                if (m_onRoomCreated) m_onRoomCreated(rb);
+                break;
+            }
+            case MsgType::ROOM_JOINED: {
+                RoomJoinedBody rb = m_protocol.readRoomJoinedBody(data, size, off);
+                if (m_onRoomJoined) m_onRoomJoined(rb);
+                listRooms();
+                break;
+            }
+            case MsgType::ROOM_LEFT: {
+                RoomLeftBody rb = m_protocol.readRoomLeftBody(data, size, off);
+                if (m_onRoomLeft) m_onRoomLeft(rb);
+                listRooms();
+                break;
+            }
+            case MsgType::ROOM_LIST: {
+                RoomListBody rb = m_protocol.readRoomListBody(data, size, off);
+                if (m_onRoomList) m_onRoomList(rb);
+                break;
+            }
+            case MsgType::ROOM_MESSAGE: {
+                RoomMessageBody rb = m_protocol.readRoomMessageBody(data, size, off);
+                if (m_onRoomMessage) m_onRoomMessage(rb);
+                break;
+            }
+            case MsgType::ROOM_ERROR: {
+                RoomErrorBody rb = m_protocol.readRoomErrorBody(data, size, off);
+                if (m_onRoomError) m_onRoomError(rb);
+                break;
+            }
+            default:
+                break;
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "processMessage exception: " << e.what() << std::endl;
+    }
+}

--- a/Client/src/net/Protocol.cpp
+++ b/Client/src/net/Protocol.cpp
@@ -1,0 +1,292 @@
+/*
+** EPITECH PROJECT, 2025
+** R-TYPE
+** File description:
+** Protocol
+*/
+
+
+#include "net/Protocol.hpp"
+#include <cstring>
+#include <boost/endian/conversion.hpp>
+#include <vector>
+#include <string>
+#include <stdexcept>
+
+namespace RtypeServer {
+    Protocol::Protocol() {}
+    Protocol::~Protocol() {}
+
+void Protocol::writeHeader(std::vector<uint8_t>& out, const NetHeader& h)
+{
+    append_u16be(out, h.magic);
+    append_u8(out, h.version);
+    append_u8(out, h.type);
+    append_u32be(out, h.seq);
+    append_u32be(out, h.ack);
+    append_u32be(out, h.ackBits);
+}
+
+NetHeader Protocol::readHeader(const uint8_t* data, std::size_t size)
+{
+    NetHeader h{};
+
+    if (size < sizeof(NetHeader))
+        throw std::runtime_error("packet too small for header");
+    std::size_t off = 0;
+    h.magic = read_u16be(data, off, size);
+    h.version = read_u8(data, off, size);
+    h.type = read_u8(data, off, size);
+    h.seq = read_u32be(data, off, size);
+    h.ack = read_u32be(data, off, size);
+    h.ackBits = read_u32be(data, off, size);
+    return h;
+}
+
+void Protocol::append_u8 (std::vector<uint8_t>& out, uint8_t v){ out.push_back(v); }
+
+void Protocol::append_u16be(std::vector<uint8_t>& out, uint16_t v)
+{
+    uint16_t be = boost::endian::native_to_big(v);
+    auto* p = reinterpret_cast<const uint8_t*>(&be);
+    out.insert(out.end(), p, p+2);
+}
+
+void Protocol::append_u32be(std::vector<uint8_t>& out, uint32_t v)
+{
+    uint32_t be = boost::endian::native_to_big(v);
+    auto* p = reinterpret_cast<const uint8_t*>(&be);
+    out.insert(out.end(), p, p+4);
+}
+
+void Protocol::append_i16be(std::vector<uint8_t>& out, int16_t v)
+{
+    int16_t be = boost::endian::native_to_big(v);
+    auto* p = reinterpret_cast<const uint8_t*>(&be);
+    out.insert(out.end(), p, p+2);
+}
+
+uint8_t  Protocol::read_u8 (const uint8_t* data, std::size_t& off, std::size_t size)
+{
+    if (off+1 > size) throw std::runtime_error("read_u8 OOB");
+    return data[off++];
+}
+
+uint16_t Protocol::read_u16be(const uint8_t* data, std::size_t& off, std::size_t size)
+{
+    if (off+2 > size) throw std::runtime_error("read_u16 OOB");
+    uint16_t be; std::memcpy(&be, data+off, 2); off += 2;
+    return boost::endian::big_to_native(be);
+}
+
+uint32_t Protocol::read_u32be(const uint8_t* data, std::size_t& off, std::size_t size)
+{
+    if (off+4 > size) throw std::runtime_error("read_u32 OOB");
+    uint32_t be; std::memcpy(&be, data+off, 4); off += 4;
+    return boost::endian::big_to_native(be);
+}
+
+int16_t  Protocol::read_i16be(const uint8_t* data, std::size_t& off, std::size_t size)
+{
+    if (off+2 > size) throw std::runtime_error("read_i16 OOB");
+    int16_t be; std::memcpy(&be, data+off, 2); off += 2;
+    return boost::endian::big_to_native(be);
+}
+
+void Protocol::writeHelloBody  (std::vector<uint8_t>& out, const HelloBody& b)
+{
+    append_u32be(out, b.client_nonce);
+    append_u8(out, b.proto);
+    uint8_t len = static_cast<uint8_t>(std::min<std::size_t>(255, b.name.size()));
+    append_u8(out, len);
+    out.insert(out.end(), b.name.data(), b.name.data()+len);
+}
+
+HelloBody Protocol::readHelloBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    HelloBody b{};
+    b.client_nonce = read_u32be(data, off, size);
+    b.proto = read_u8(data, off, size);
+    uint8_t len = read_u8(data, off, size);
+    if (off + len > size) throw std::runtime_error("hello name OOB");
+    b.name.assign(reinterpret_cast<const char*>(data+off), len);
+    off += len;
+    return b;
+}
+
+void Protocol::writeWelcomeBody(std::vector<uint8_t>& out, const WelcomeBody& b)
+{
+    append_u32be(out, b.playerId);
+    append_u16be(out, b.roomId);
+    append_u32be(out, b.baselineTick);
+}
+
+WelcomeBody Protocol::readWelcomeBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    WelcomeBody b{};
+    b.playerId = read_u32be(data, off, size);
+    b.roomId = read_u16be(data, off, size);
+    b.baselineTick = read_u32be(data, off, size);
+    return b;
+}
+
+void Protocol::writeString(std::vector<uint8_t>& out, const std::string& str)
+{
+    uint16_t len = static_cast<uint16_t>(std::min<std::size_t>(65535, str.size()));
+    append_u16be(out, len);
+    out.insert(out.end(), str.data(), str.data() + len);
+}
+
+std::string Protocol::readString(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    uint16_t len = read_u16be(data, off, size);
+    if (off + len > size) throw std::runtime_error("string OOB");
+    std::string str(reinterpret_cast<const char*>(data + off), len);
+    off += len;
+    return str;
+}
+
+void Protocol::writeCreateRoomBody(std::vector<uint8_t>& out, const CreateRoomBody& b)
+{
+    writeString(out, b.roomName);
+    append_u8(out, b.maxPlayers);
+}
+
+CreateRoomBody Protocol::readCreateRoomBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    CreateRoomBody b{};
+    b.roomName = readString(data, size, off);
+    b.maxPlayers = read_u8(data, off, size);
+    return b;
+}
+
+void Protocol::writeJoinRoomBody(std::vector<uint8_t>& out, const JoinRoomBody& b)
+{
+    writeString(out, b.roomName);
+}
+
+JoinRoomBody Protocol::readJoinRoomBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    JoinRoomBody b{};
+    b.roomName = readString(data, size, off);
+    return b;
+}
+
+void Protocol::writeMessageBody(std::vector<uint8_t>& out, const MessageBody& b)
+{
+    writeString(out, b.message);
+}
+
+MessageBody Protocol::readMessageBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    MessageBody b{};
+    b.message = readString(data, size, off);
+    return b;
+}
+
+void Protocol::writeRoomCreatedBody(std::vector<uint8_t>& out, const RoomCreatedBody& b)
+{
+    append_u32be(out, b.roomId);
+    writeString(out, b.roomName);
+    append_u8(out, b.success);
+}
+
+RoomCreatedBody Protocol::readRoomCreatedBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    RoomCreatedBody b{};
+    b.roomId = read_u32be(data, off, size);
+    b.roomName = readString(data, size, off);
+    b.success = read_u8(data, off, size);
+    return b;
+}
+
+void Protocol::writeRoomJoinedBody(std::vector<uint8_t>& out, const RoomJoinedBody& b)
+{
+    append_u32be(out, b.roomId);
+    writeString(out, b.roomName);
+    append_u8(out, b.success);
+    append_u8(out, b.playerCount);
+}
+
+RoomJoinedBody Protocol::readRoomJoinedBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    RoomJoinedBody b{};
+    b.roomId = read_u32be(data, off, size);
+    b.roomName = readString(data, size, off);
+    b.success = read_u8(data, off, size);
+    b.playerCount = read_u8(data, off, size);
+    return b;
+}
+
+void Protocol::writeRoomLeftBody(std::vector<uint8_t>& out, const RoomLeftBody& b)
+{
+    append_u32be(out, b.roomId);
+    append_u8(out, b.success);
+}
+
+RoomLeftBody Protocol::readRoomLeftBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    RoomLeftBody b{};
+    b.roomId = read_u32be(data, off, size);
+    b.success = read_u8(data, off, size);
+    return b;
+}
+
+void Protocol::writeRoomListBody(std::vector<uint8_t>& out, const RoomListBody& b)
+{
+    append_u16be(out, static_cast<uint16_t>(b.rooms.size()));
+    for (const auto& room : b.rooms) {
+        append_u32be(out, room.roomId);
+        writeString(out, room.roomName);
+        append_u8(out, room.currentPlayers);
+        append_u8(out, room.maxPlayers);
+    }
+}
+
+RoomListBody Protocol::readRoomListBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    RoomListBody b{};
+    uint16_t roomCount = read_u16be(data, off, size);
+    b.rooms.reserve(roomCount);
+    for (uint16_t i = 0; i < roomCount; ++i) {
+        RoomInfoEntry entry{};
+        entry.roomId = read_u32be(data, off, size);
+        entry.roomName = readString(data, size, off);
+        entry.currentPlayers = read_u8(data, off, size);
+        entry.maxPlayers = read_u8(data, off, size);
+        b.rooms.push_back(entry);
+    }
+    return b;
+}
+
+void Protocol::writeRoomMessageBody(std::vector<uint8_t>& out, const RoomMessageBody& b)
+{
+    append_u32be(out, b.senderId);
+    writeString(out, b.senderName);
+    writeString(out, b.message);
+}
+
+RoomMessageBody Protocol::readRoomMessageBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    RoomMessageBody b{};
+    b.senderId = read_u32be(data, off, size);
+    b.senderName = readString(data, size, off);
+    b.message = readString(data, size, off);
+    return b;
+}
+
+void Protocol::writeRoomErrorBody(std::vector<uint8_t>& out, const RoomErrorBody& b)
+{
+    append_u8(out, b.errorCode);
+    writeString(out, b.errorMessage);
+}
+
+RoomErrorBody Protocol::readRoomErrorBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    RoomErrorBody b{};
+    b.errorCode = read_u8(data, off, size);
+    b.errorMessage = readString(data, size, off);
+    return b;
+}
+
+} // namespace RtypeServer

--- a/Server/src/net/ClientSession.hpp
+++ b/Server/src/net/ClientSession.hpp
@@ -1,0 +1,33 @@
+/*
+** EPITECH PROJECT, 2025
+** G-CPP-500-BDX-5-1-rtype-1
+** File description:
+** ClientSession
+*/
+
+#ifndef CLIENTSESSION_HPP_
+#define CLIENTSESSION_HPP_
+
+#include <boost/asio.hpp>
+#include <memory>
+#include <string>
+#include <chrono>
+
+namespace RtypeServer {
+
+    class Room;
+
+    struct ClientSession {
+        using clock = std::chrono::steady_clock;
+        
+        uint32_t playerId = 0;
+        std::string playerName;
+        boost::asio::ip::udp::endpoint endpoint;
+        clock::time_point lastSeen{};
+        clock::time_point lastPing{};
+        std::shared_ptr<Room> currentRoom;
+    };
+
+}
+
+#endif /* !CLIENTSESSION_HPP_ */

--- a/Server/src/net/Protocol.cpp
+++ b/Server/src/net/Protocol.cpp
@@ -83,9 +83,9 @@ uint8_t  RtypeServer::Protocol::read_u8 (const uint8_t* data, std::size_t& off, 
 
 uint16_t RtypeServer::Protocol::read_u16be(const uint8_t* data, std::size_t& off, std::size_t size)
 {
-    if (off+4 > size)
-        throw std::runtime_error("read_u32 OOB");
-    uint32_t be; std::memcpy(&be, data+off, 4); off += 4;
+    if (off+2 > size)
+        throw std::runtime_error("read_u16 OOB");
+    uint16_t be; std::memcpy(&be, data+off, 2); off += 2;
     return boost::endian::big_to_native(be);
 
 }
@@ -145,6 +145,166 @@ RtypeServer::WelcomeBody RtypeServer::Protocol::readWelcomeBody(const uint8_t* d
     b.roomId = read_u16be(data, off, size);
     b.baselineTick = read_u32be(data, off, size);
     return b;
+}
 
+void RtypeServer::Protocol::writeString(std::vector<uint8_t>& out, const std::string& str)
+{
+    uint16_t len = static_cast<uint16_t>(std::min<std::size_t>(65535, str.size()));
+    append_u16be(out, len);
+    out.insert(out.end(), str.data(), str.data() + len);
+}
+
+std::string RtypeServer::Protocol::readString(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    uint16_t len = read_u16be(data, off, size);
+    if (off + len > size) 
+        throw std::runtime_error("string OOB");
+    std::string str(reinterpret_cast<const char*>(data + off), len);
+    off += len;
+    return str;
+}
+
+void RtypeServer::Protocol::writeCreateRoomBody(std::vector<uint8_t>& out, const CreateRoomBody& b)
+{
+    writeString(out, b.roomName);
+    append_u8(out, b.maxPlayers);
+}
+
+RtypeServer::CreateRoomBody RtypeServer::Protocol::readCreateRoomBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    CreateRoomBody b{};
+    b.roomName = readString(data, size, off);
+    b.maxPlayers = read_u8(data, off, size);
+    return b;
+}
+
+void RtypeServer::Protocol::writeJoinRoomBody(std::vector<uint8_t>& out, const JoinRoomBody& b)
+{
+    writeString(out, b.roomName);
+}
+
+RtypeServer::JoinRoomBody RtypeServer::Protocol::readJoinRoomBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    JoinRoomBody b{};
+    b.roomName = readString(data, size, off);
+    return b;
+}
+
+void RtypeServer::Protocol::writeMessageBody(std::vector<uint8_t>& out, const MessageBody& b)
+{
+    writeString(out, b.message);
+}
+
+RtypeServer::MessageBody RtypeServer::Protocol::readMessageBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    MessageBody b{};
+    b.message = readString(data, size, off);
+    return b;
+}
+
+void RtypeServer::Protocol::writeRoomCreatedBody(std::vector<uint8_t>& out, const RoomCreatedBody& b)
+{
+    append_u32be(out, b.roomId);
+    writeString(out, b.roomName);
+    append_u8(out, b.success);
+}
+
+RtypeServer::RoomCreatedBody RtypeServer::Protocol::readRoomCreatedBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    RoomCreatedBody b{};
+    b.roomId = read_u32be(data, off, size);
+    b.roomName = readString(data, size, off);
+    b.success = read_u8(data, off, size);
+    return b;
+}
+
+void RtypeServer::Protocol::writeRoomJoinedBody(std::vector<uint8_t>& out, const RoomJoinedBody& b)
+{
+    append_u32be(out, b.roomId);
+    writeString(out, b.roomName);
+    append_u8(out, b.success);
+    append_u8(out, b.playerCount);
+}
+
+RtypeServer::RoomJoinedBody RtypeServer::Protocol::readRoomJoinedBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    RoomJoinedBody b{};
+    b.roomId = read_u32be(data, off, size);
+    b.roomName = readString(data, size, off);
+    b.success = read_u8(data, off, size);
+    b.playerCount = read_u8(data, off, size);
+    return b;
+}
+
+void RtypeServer::Protocol::writeRoomLeftBody(std::vector<uint8_t>& out, const RoomLeftBody& b)
+{
+    append_u32be(out, b.roomId);
+    append_u8(out, b.success);
+}
+
+RtypeServer::RoomLeftBody RtypeServer::Protocol::readRoomLeftBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    RoomLeftBody b{};
+    b.roomId = read_u32be(data, off, size);
+    b.success = read_u8(data, off, size);
+    return b;
+}
+
+void RtypeServer::Protocol::writeRoomListBody(std::vector<uint8_t>& out, const RoomListBody& b)
+{
+    append_u16be(out, static_cast<uint16_t>(b.rooms.size()));
+    for (const auto& room : b.rooms) {
+        append_u32be(out, room.roomId);
+        writeString(out, room.roomName);
+        append_u8(out, room.currentPlayers);
+        append_u8(out, room.maxPlayers);
+    }
+}
+
+RtypeServer::RoomListBody RtypeServer::Protocol::readRoomListBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    RoomListBody b{};
+    uint16_t roomCount = read_u16be(data, off, size);
+    b.rooms.reserve(roomCount);
+    
+    for (uint16_t i = 0; i < roomCount; ++i) {
+        RoomInfoEntry entry{};
+        entry.roomId = read_u32be(data, off, size);
+        entry.roomName = readString(data, size, off);
+        entry.currentPlayers = read_u8(data, off, size);
+        entry.maxPlayers = read_u8(data, off, size);
+        b.rooms.push_back(entry);
+    }
+    return b;
+}
+
+void RtypeServer::Protocol::writeRoomMessageBody(std::vector<uint8_t>& out, const RoomMessageBody& b)
+{
+    append_u32be(out, b.senderId);
+    writeString(out, b.senderName);
+    writeString(out, b.message);
+}
+
+RtypeServer::RoomMessageBody RtypeServer::Protocol::readRoomMessageBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    RoomMessageBody b{};
+    b.senderId = read_u32be(data, off, size);
+    b.senderName = readString(data, size, off);
+    b.message = readString(data, size, off);
+    return b;
+}
+
+void RtypeServer::Protocol::writeRoomErrorBody(std::vector<uint8_t>& out, const RoomErrorBody& b)
+{
+    append_u8(out, b.errorCode);
+    writeString(out, b.errorMessage);
+}
+
+RtypeServer::RoomErrorBody RtypeServer::Protocol::readRoomErrorBody(const uint8_t* data, std::size_t size, std::size_t& off)
+{
+    RoomErrorBody b{};
+    b.errorCode = read_u8(data, off, size);
+    b.errorMessage = readString(data, size, off);
+    return b;
 }
 

--- a/Server/src/net/Protocol.hpp
+++ b/Server/src/net/Protocol.hpp
@@ -30,13 +30,24 @@ namespace RtypeServer {
     };
 
     enum class MsgType : uint8_t {
-        HELLO    = 1,
-        WELCOME  = 2,
-        PING     = 3,
-        PONG     = 4,
-        INPUT    = 10,
+        HELLO = 1,
+        WELCOME = 2,
+        PING = 3,
+        PONG = 4,
+        INPUT = 10,
         SNAPSHOT = 11,
-        EVENT    = 12,
+        EVENT = 12,
+        CREATE_ROOM = 20,
+        JOIN_ROOM = 21,
+        LEAVE_ROOM = 22,
+        LIST_ROOMS = 23,
+        MESSAGE = 24,
+        ROOM_CREATED = 30,
+        ROOM_JOINED = 31,
+        ROOM_LEFT = 32,
+        ROOM_LIST = 33,
+        ROOM_MESSAGE = 34,
+        ROOM_ERROR = 35,
     };
 
     struct HelloBody {
@@ -49,6 +60,59 @@ namespace RtypeServer {
         uint32_t playerId = 0;
         uint16_t roomId = 0;
         uint32_t baselineTick = 0;
+    };
+
+    struct CreateRoomBody {
+        std::string roomName;
+        uint8_t maxPlayers = 4;
+    };
+
+    struct JoinRoomBody {
+        std::string roomName;
+    };
+
+    struct MessageBody {
+        std::string message;
+    };
+
+    struct RoomCreatedBody {
+        uint32_t roomId = 0;
+        std::string roomName;
+        uint8_t success = 1;
+    };
+
+    struct RoomJoinedBody {
+        uint32_t roomId = 0;
+        std::string roomName;
+        uint8_t success = 1;
+        uint8_t playerCount = 0;
+    };
+
+    struct RoomLeftBody {
+        uint32_t roomId = 0;
+        uint8_t success = 1;
+    };
+
+    struct RoomInfoEntry {
+        uint32_t roomId = 0;
+        std::string roomName;
+        uint8_t currentPlayers = 0;
+        uint8_t maxPlayers = 0;
+    };
+
+    struct RoomListBody {
+        std::vector<RoomInfoEntry> rooms;
+    };
+
+    struct RoomMessageBody {
+        uint32_t senderId = 0;
+        std::string senderName;
+        std::string message;
+    };
+
+    struct RoomErrorBody {
+        uint8_t errorCode = 0;
+        std::string errorMessage;
     };
 
     class Protocol {
@@ -70,6 +134,27 @@ namespace RtypeServer {
             HelloBody readHelloBody(const uint8_t* data, std::size_t size, std::size_t& off);
             void writeWelcomeBody(std::vector<uint8_t>& out, const WelcomeBody& b);
             WelcomeBody readWelcomeBody(const uint8_t* data, std::size_t size, std::size_t& off);
+
+            void writeCreateRoomBody(std::vector<uint8_t>& out, const CreateRoomBody& b);
+            CreateRoomBody readCreateRoomBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeJoinRoomBody(std::vector<uint8_t>& out, const JoinRoomBody& b);
+            JoinRoomBody readJoinRoomBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeMessageBody(std::vector<uint8_t>& out, const MessageBody& b);
+            MessageBody readMessageBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeRoomCreatedBody(std::vector<uint8_t>& out, const RoomCreatedBody& b);
+            RoomCreatedBody readRoomCreatedBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeRoomJoinedBody(std::vector<uint8_t>& out, const RoomJoinedBody& b);
+            RoomJoinedBody readRoomJoinedBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeRoomLeftBody(std::vector<uint8_t>& out, const RoomLeftBody& b);
+            RoomLeftBody readRoomLeftBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeRoomListBody(std::vector<uint8_t>& out, const RoomListBody& b);
+            RoomListBody readRoomListBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeRoomMessageBody(std::vector<uint8_t>& out, const RoomMessageBody& b);
+            RoomMessageBody readRoomMessageBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeRoomErrorBody(std::vector<uint8_t>& out, const RoomErrorBody& b);
+            RoomErrorBody readRoomErrorBody(const uint8_t* data, std::size_t size, std::size_t& off);
+            void writeString(std::vector<uint8_t>& out, const std::string& str);
+            std::string readString(const uint8_t* data, std::size_t size, std::size_t& off);
 
         protected:
         private:

--- a/Server/src/net/Room.cpp
+++ b/Server/src/net/Room.cpp
@@ -1,0 +1,84 @@
+/*
+** EPITECH PROJECT, 2025
+** G-CPP-500-BDX-5-1-rtype-1
+** File description:
+** Room
+*/
+
+#include "Room.hpp"
+#include "../util/Log.hpp"
+#include <algorithm>
+
+namespace RtypeServer {
+
+Room::Room(const std::string& name, uint32_t roomId)
+    : m_name(name), m_roomId(roomId)
+{
+    infof("Room created: '%s' (ID: %u)", name.c_str(), roomId);
+}
+
+bool Room::join(std::shared_ptr<ClientSession> client)
+{
+    if (!client) {
+        warnf("Attempted to add null client to room '%s'", m_name.c_str());
+        return false;
+    }
+    if (isFull()) {
+        warnf("Room '%s' is full (%zu/%zu players)", m_name.c_str(), m_clients.size(), m_maxPlayers);
+        return false;
+    }
+    auto it = std::find(m_clients.begin(), m_clients.end(), client);
+    if (it != m_clients.end()) {
+        warnf("Client (playerId=%u) is already in room '%s'", client->playerId, m_name.c_str());
+        return false;
+    }
+    if (client->currentRoom && client->currentRoom.get() != this) {
+        client->currentRoom->leave(client);
+    }
+    m_clients.push_back(client);
+    infof("Client (playerId=%u) joined room '%s' (%zu/%zu players)", 
+          client->playerId, m_name.c_str(), m_clients.size(), m_maxPlayers);
+    return true;
+}
+
+void Room::leave(std::shared_ptr<ClientSession> client)
+{
+    if (!client) return;
+    auto it = std::find(m_clients.begin(), m_clients.end(), client);
+    if (it != m_clients.end()) {
+        m_clients.erase(it);
+        client->currentRoom.reset();
+        infof("Client (playerId=%u) left room '%s' (%zu/%zu players)", 
+              client->playerId, m_name.c_str(), m_clients.size(), m_maxPlayers);
+    }
+}
+
+void Room::broadcast(const std::vector<uint8_t>& message, std::shared_ptr<ClientSession> excludeClient)
+{
+    if (!m_socket) {
+        warnf("Cannot broadcast to room '%s': no socket set", m_name.c_str());
+        return;
+    }
+    size_t sentCount = 0;
+    for (const auto& client : m_clients) {
+        if (client && client != excludeClient) {
+            auto buf = std::make_shared<std::vector<uint8_t>>(message);
+            m_socket->async_send_to(
+                boost::asio::buffer(*buf), client->endpoint,
+                [buf, client, this](boost::system::error_code ec, std::size_t) {
+                    if (ec) {
+                        auto addr = client->endpoint.address().to_string();
+                        warnf("Failed to send message to client (playerId=%u) at %s:%u in room '%s': %s",
+                              client->playerId, addr.c_str(), client->endpoint.port(), 
+                              m_name.c_str(), ec.message().c_str());
+                    }
+                });
+            sentCount++;
+        }
+    }
+    if (sentCount > 0) {
+        infof("Broadcasted message to %zu clients in room '%s'", sentCount, m_name.c_str());
+    }
+}
+
+} // namespace RtypeServer

--- a/Server/src/net/Room.hpp
+++ b/Server/src/net/Room.hpp
@@ -1,0 +1,47 @@
+/*
+** EPITECH PROJECT, 2025
+** G-CPP-500-BDX-5-1-rtype-1
+** File description:
+** Room
+*/
+
+#ifndef ROOM_HPP_
+#define ROOM_HPP_
+
+#include <vector>
+#include <memory>
+#include <string>
+#include <functional>
+#include <boost/asio.hpp>
+#include "ClientSession.hpp"
+
+namespace RtypeServer {
+
+    class Room {
+    public:
+        Room(const std::string& name, uint32_t roomId);
+        ~Room() = default;
+        bool join(std::shared_ptr<ClientSession> client);
+        void leave(std::shared_ptr<ClientSession> client);
+        void broadcast(const std::vector<uint8_t>& message, std::shared_ptr<ClientSession> excludeClient = nullptr);
+        const std::string& getName() const { return m_name; }
+        uint32_t getRoomId() const { return m_roomId; }
+        size_t getPlayerCount() const { return m_clients.size(); }
+        const std::vector<std::shared_ptr<ClientSession>>& getClients() const { return m_clients; }
+        void setMaxPlayers(size_t maxPlayers) { m_maxPlayers = maxPlayers; }
+        size_t getMaxPlayers() const { return m_maxPlayers; }
+        bool isFull() const { return m_clients.size() >= m_maxPlayers; }
+        bool isEmpty() const { return m_clients.empty(); }
+        void setSocket(boost::asio::ip::udp::socket* socket) { m_socket = socket; }
+
+    private:
+        std::string m_name;
+        uint32_t m_roomId;
+        std::vector<std::shared_ptr<ClientSession>> m_clients;
+        size_t m_maxPlayers = 4;
+        boost::asio::ip::udp::socket* m_socket = nullptr;
+    };
+
+} // namespace RtypeServer
+
+#endif /* !ROOM_HPP_ */

--- a/Server/src/net/RoomManager.cpp
+++ b/Server/src/net/RoomManager.cpp
@@ -1,0 +1,200 @@
+/*
+** EPITECH PROJECT, 2025
+** G-CPP-500-BDX-5-1-rtype-1
+** File description:
+** RoomManager
+*/
+
+#include "RoomManager.hpp"
+#include "../util/Log.hpp"
+#include <algorithm>
+
+namespace RtypeServer {
+
+RoomManager::RoomManager()
+{
+    infof("RoomManager initialized");
+}
+
+std::shared_ptr<Room> RoomManager::createRoom(const std::string& name, size_t maxPlayers)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_roomsByName.find(name) != m_roomsByName.end()) {
+        warnf("Room with name '%s' already exists", name.c_str());
+        return nullptr;
+    }
+    uint32_t roomId = m_nextRoomId++;
+    auto room = std::make_shared<Room>(name, roomId);
+    room->setMaxPlayers(maxPlayers);
+    if (m_socket) {
+        room->setSocket(m_socket);
+    }
+    m_roomsByName[name] = room;
+    m_roomsById[roomId] = room;
+    infof("Created room '%s' (ID: %u) with max %zu players", name.c_str(), roomId, maxPlayers);
+    return room;
+}
+
+std::shared_ptr<Room> RoomManager::getRoom(const std::string& name)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_roomsByName.find(name);
+    return (it != m_roomsByName.end()) ? it->second : nullptr;
+}
+
+std::shared_ptr<Room> RoomManager::getRoom(uint32_t roomId)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_roomsById.find(roomId);
+    return (it != m_roomsById.end()) ? it->second : nullptr;
+}
+
+bool RoomManager::removeRoom(const std::string& name)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    
+    auto it = m_roomsByName.find(name);
+    if (it == m_roomsByName.end()) {
+        return false;
+    }
+    uint32_t roomId = it->second->getRoomId();
+    auto clients = it->second->getClients();
+    for (auto& client : clients) {
+        it->second->leave(client);
+    }
+    m_roomsByName.erase(it);
+    m_roomsById.erase(roomId);
+    infof("Removed room '%s' (ID: %u)", name.c_str(), roomId);
+    return true;
+}
+
+bool RoomManager::removeRoom(uint32_t roomId)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    
+    auto it = m_roomsById.find(roomId);
+    if (it == m_roomsById.end()) {
+        return false;
+    }
+    
+    std::string name = it->second->getName();
+    auto clients = it->second->getClients();
+    for (auto& client : clients) {
+        it->second->leave(client);
+    }
+    m_roomsByName.erase(name);
+    m_roomsById.erase(it);
+    infof("Removed room '%s' (ID: %u)", name.c_str(), roomId);
+    return true;
+}
+
+std::vector<RoomInfo> RoomManager::listRooms() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    
+    std::vector<RoomInfo> rooms;
+    rooms.reserve(m_roomsByName.size());
+    for (const auto& [name, room] : m_roomsByName) {
+        rooms.emplace_back(
+            room->getName(),
+            room->getRoomId(),
+            room->getPlayerCount(),
+            room->getMaxPlayers()
+        );
+    }
+    return rooms;
+}
+
+size_t RoomManager::getRoomCount() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_roomsByName.size();
+}
+
+void RoomManager::cleanup()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    std::vector<std::string> toRemove;
+    
+    for (const auto& [name, room] : m_roomsByName) {
+        if (room->isEmpty()) {
+            toRemove.push_back(name);
+        }
+    }
+    for (const auto& name : toRemove) {
+        auto it = m_roomsByName.find(name);
+        if (it != m_roomsByName.end()) {
+            uint32_t roomId = it->second->getRoomId();
+            m_roomsById.erase(roomId);
+            m_roomsByName.erase(it);
+            infof("Auto-removed empty room '%s'", name.c_str());
+        }
+    }
+}
+
+bool RoomManager::roomExists(const std::string& name) const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_roomsByName.find(name) != m_roomsByName.end();
+}
+
+bool RoomManager::roomExists(uint32_t roomId) const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_roomsById.find(roomId) != m_roomsById.end();
+}
+
+void RoomManager::setSocket(boost::asio::ip::udp::socket* socket)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_socket = socket;
+
+    for (auto& [name, room] : m_roomsByName) {
+        room->setSocket(socket);
+    }
+}
+
+bool RoomManager::joinRoom(std::shared_ptr<ClientSession> client, const std::string& roomName)
+{
+    if (!client) return false;
+    
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_roomsByName.find(roomName);
+    if (it == m_roomsByName.end()) {
+        return false;
+    }
+    auto room = it->second;
+    if (room->join(client)) {
+        client->currentRoom = room;
+        return true;
+    }
+    return false;
+}
+
+bool RoomManager::joinRoom(std::shared_ptr<ClientSession> client, uint32_t roomId)
+{
+    if (!client) return false;
+    
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_roomsById.find(roomId);
+    if (it == m_roomsById.end()) {
+        return false;
+    }
+    auto room = it->second;
+    if (room->join(client)) {
+        client->currentRoom = room;
+        return true;
+    }
+    return false;
+}
+
+void RoomManager::leaveRoom(std::shared_ptr<ClientSession> client)
+{
+    if (!client || !client->currentRoom) return;
+    
+    std::lock_guard<std::mutex> lock(m_mutex);
+    client->currentRoom->leave(client);
+    client->currentRoom.reset();
+}
+
+} // namespace RtypeServer

--- a/Server/src/net/RoomManager.hpp
+++ b/Server/src/net/RoomManager.hpp
@@ -1,0 +1,59 @@
+/*
+** EPITECH PROJECT, 2025
+** G-CPP-500-BDX-5-1-rtype-1
+** File description:
+** RoomManager
+*/
+
+#ifndef ROOMMANAGER_HPP_
+#define ROOMMANAGER_HPP_
+
+#include "Room.hpp"
+#include <unordered_map>
+#include <memory>
+#include <string>
+#include <vector>
+#include <mutex>
+
+namespace RtypeServer {
+
+    struct RoomInfo {
+        std::string name;
+        uint32_t roomId;
+        size_t currentPlayers;
+        size_t maxPlayers;
+        
+        RoomInfo(const std::string& n, uint32_t id, size_t current, size_t max)
+            : name(n), roomId(id), currentPlayers(current), maxPlayers(max) {}
+    };
+
+    class RoomManager {
+    public:
+        RoomManager();
+        ~RoomManager() = default;
+        std::shared_ptr<Room> createRoom(const std::string& name, size_t maxPlayers = 4);
+        std::shared_ptr<Room> getRoom(const std::string& name);
+        std::shared_ptr<Room> getRoom(uint32_t roomId);
+        bool removeRoom(const std::string& name);
+        bool removeRoom(uint32_t roomId);
+        std::vector<RoomInfo> listRooms() const;
+        size_t getRoomCount() const;
+        void cleanup();
+        bool roomExists(const std::string& name) const;
+        bool roomExists(uint32_t roomId) const;
+        void setSocket(boost::asio::ip::udp::socket* socket);
+        bool joinRoom(std::shared_ptr<ClientSession> client, const std::string& roomName);
+        bool joinRoom(std::shared_ptr<ClientSession> client, uint32_t roomId);
+        void leaveRoom(std::shared_ptr<ClientSession> client);
+
+    private:
+        mutable std::mutex m_mutex;
+        std::unordered_map<std::string, std::shared_ptr<Room>> m_roomsByName;
+        std::unordered_map<uint32_t, std::shared_ptr<Room>> m_roomsById;
+        uint32_t m_nextRoomId = 1;
+        boost::asio::ip::udp::socket* m_socket = nullptr;
+    };
+
+} // namespace RtypeServer
+
+#endif /* !ROOMMANAGER_HPP_ */

--- a/Server/src/net/UdpServer.cpp
+++ b/Server/src/net/UdpServer.cpp
@@ -7,6 +7,8 @@
 
 #include "UdpServer.hpp"
 #include "Protocol.hpp"
+#include "Room.hpp"
+#include "RoomManager.hpp"
 #include "../util/Log.hpp"
 
 namespace RtypeServer {
@@ -14,9 +16,10 @@ namespace RtypeServer {
 using udp = boost::asio::ip::udp;
 
 RtypeServer::UdpServer::UdpServer(boost::asio::io_context& io, uint16_t port) :
-    m_socket(io, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), port)), m_timer(io), m_protocol()
+    m_socket(io, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), port)), m_timer(io), m_protocol(), m_roomManager()
 {
     infof("UDP listening on port %u", port);
+    m_roomManager.setSocket(&m_socket);
     start_receive();
     start_heartbeat();
 }
@@ -52,7 +55,7 @@ void RtypeServer::UdpServer::handle_receive(std::size_t bytes)
         const auto key = endpointKey(m_remote);
         auto it = m_sessions.find(key);
         if (it != m_sessions.end()) {
-            it->second.lastSeen = clock::now();
+            it->second->lastSeen = clock::now();
         }
         std::size_t off = sizeof(NetHeader);
         switch (static_cast<MsgType>(hdr.type)) {
@@ -63,10 +66,11 @@ void RtypeServer::UdpServer::handle_receive(std::size_t bytes)
                            hello.name.c_str(), hello.client_nonce);
 
                 uint32_t playerId = m_nextPlayerId++;
-                ClientSession s;
-                s.playerId = playerId;
-                s.endpoint = m_remote;
-                s.lastSeen = clock::now();
+                auto s = std::make_shared<ClientSession>();
+                s->playerId = playerId;
+                s->playerName = hello.name;
+                s->endpoint = m_remote;
+                s->lastSeen = clock::now();
                 m_sessions[key] = s;
 
                 send_welcome(m_remote, playerId);
@@ -80,7 +84,40 @@ void RtypeServer::UdpServer::handle_receive(std::size_t bytes)
             }
             case MsgType::PONG: {
                 if (it != m_sessions.end()) {
-                    it->second.lastSeen = clock::now();
+                    it->second->lastSeen = clock::now();
+                }
+                break;
+            }
+            case MsgType::CREATE_ROOM: {
+                if (it != m_sessions.end()) {
+                    auto createRoom = m_protocol.readCreateRoomBody(m_rxBuf.data(), bytes, off);
+                    handle_create_room(it->second, createRoom);
+                }
+                break;
+            }
+            case MsgType::JOIN_ROOM: {
+                if (it != m_sessions.end()) {
+                    auto joinRoom = m_protocol.readJoinRoomBody(m_rxBuf.data(), bytes, off);
+                    handle_join_room(it->second, joinRoom);
+                }
+                break;
+            }
+            case MsgType::LEAVE_ROOM: {
+                if (it != m_sessions.end()) {
+                    handle_leave_room(it->second);
+                }
+                break;
+            }
+            case MsgType::LIST_ROOMS: {
+                if (it != m_sessions.end()) {
+                    handle_list_rooms(it->second);
+                }
+                break;
+            }
+            case MsgType::MESSAGE: {
+                if (it != m_sessions.end()) {
+                    auto message = m_protocol.readMessageBody(m_rxBuf.data(), bytes, off);
+                    handle_message(it->second, message);
                 }
                 break;
             }
@@ -98,11 +135,11 @@ void RtypeServer::UdpServer::handle_receive(std::size_t bytes)
 void UdpServer::send_pong(const udp::endpoint& to, uint32_t seq)
 {
     NetHeader h{};
-    h.magic   = kMagic;
+    h.magic = kMagic;
     h.version = kProtoVersion;
-    h.type    = static_cast<uint8_t>(MsgType::PONG);
-    h.seq     = seq;
-    h.ack     = 0; h.ackBits = 0;
+    h.type = static_cast<uint8_t>(MsgType::PONG);
+    h.seq = seq;
+    h.ack = 0; h.ackBits = 0;
 
     auto buf = std::make_shared<std::vector<uint8_t>>();
     m_protocol.writeHeader(*buf, h);
@@ -173,17 +210,17 @@ void UdpServer::start_heartbeat()
         const auto now = clock::now();
         std::vector<std::string> toErase;
         for (auto& [key, s] : m_sessions) {
-            auto sinceSeen = std::chrono::duration_cast<std::chrono::seconds>(now - s.lastSeen).count();
-            auto sincePing = std::chrono::duration_cast<std::chrono::seconds>(now - s.lastPing).count();
+            auto sinceSeen = std::chrono::duration_cast<std::chrono::seconds>(now - s->lastSeen).count();
+            auto sincePing = std::chrono::duration_cast<std::chrono::seconds>(now - s->lastPing).count();
             if (sinceSeen >= 5) {
                 infof("Session timeout playerId=%u (%s:%u)",
-                           s.playerId, s.endpoint.address().to_string().c_str(), s.endpoint.port());
+                           s->playerId, s->endpoint.address().to_string().c_str(), s->endpoint.port());
                 toErase.push_back(key);
                 continue;
             }
             if (sincePing >= 2) {
-                send_ping(s.endpoint);
-                s.lastPing = now;
+                send_ping(s->endpoint);
+                s->lastPing = now;
             }
         }
         for (auto& k : toErase) {
@@ -197,4 +234,248 @@ std::string UdpServer::endpointKey(const udp::endpoint& ep)
 {
     return ep.address().to_string() + ":" + std::to_string(ep.port());
 }
+
+void UdpServer::send_room_created(const udp::endpoint& to, uint32_t roomId, const std::string& roomName, bool success)
+{
+    NetHeader h{};
+    h.magic = kMagic;
+    h.version = kProtoVersion;
+    h.type = static_cast<uint8_t>(MsgType::ROOM_CREATED);
+    h.seq = 0; h.ack = 0; h.ackBits = 0;
+
+    auto buf = std::make_shared<std::vector<uint8_t>>();
+    m_protocol.writeHeader(*buf, h);
+    RoomCreatedBody body{};
+    body.roomId = roomId;
+    body.roomName = roomName;
+    body.success = success ? 1 : 0;
+    m_protocol.writeRoomCreatedBody(*buf, body);
+    
+    m_socket.async_send_to(boost::asio::buffer(*buf), to,
+        [buf, to, roomName, success](boost::system::error_code ec, std::size_t) {
+            if (ec) {
+                auto addr = to.address().to_string();
+                warnf("send ROOM_CREATED to %s:%u failed: %s", addr.c_str(), to.port(), ec.message().c_str());
+            } else {
+                auto addr = to.address().to_string();
+                infof("ROOM_CREATED sent to %s:%u room='%s' success=%d", addr.c_str(), to.port(), roomName.c_str(), success);
+            }
+        });
+}
+
+void UdpServer::send_room_joined(const udp::endpoint& to, uint32_t roomId, const std::string& roomName, bool success, uint8_t playerCount)
+{
+    NetHeader h{};
+    h.magic = kMagic;
+    h.version = kProtoVersion;
+    h.type = static_cast<uint8_t>(MsgType::ROOM_JOINED);
+    h.seq = 0; h.ack = 0; h.ackBits = 0;
+
+    auto buf = std::make_shared<std::vector<uint8_t>>();
+    m_protocol.writeHeader(*buf, h);
+    RoomJoinedBody body{};
+    body.roomId = roomId;
+    body.roomName = roomName;
+    body.success = success ? 1 : 0;
+    body.playerCount = playerCount;
+    m_protocol.writeRoomJoinedBody(*buf, body);
+    
+    m_socket.async_send_to(boost::asio::buffer(*buf), to,
+        [buf, to, roomName, success](boost::system::error_code ec, std::size_t) {
+            if (ec) {
+                auto addr = to.address().to_string();
+                warnf("send ROOM_JOINED to %s:%u failed: %s", addr.c_str(), to.port(), ec.message().c_str());
+            } else {
+                auto addr = to.address().to_string();
+                infof("ROOM_JOINED sent to %s:%u room='%s' success=%d", addr.c_str(), to.port(), roomName.c_str(), success);
+            }
+        });
+}
+
+void UdpServer::send_room_left(const udp::endpoint& to, uint32_t roomId, bool success)
+{
+    NetHeader h{};
+    h.magic = kMagic;
+    h.version = kProtoVersion;
+    h.type = static_cast<uint8_t>(MsgType::ROOM_LEFT);
+    h.seq = 0; h.ack = 0; h.ackBits = 0;
+
+    auto buf = std::make_shared<std::vector<uint8_t>>();
+    m_protocol.writeHeader(*buf, h);
+    RoomLeftBody body{};
+    body.roomId = roomId;
+    body.success = success ? 1 : 0;
+    m_protocol.writeRoomLeftBody(*buf, body);
+    
+    m_socket.async_send_to(boost::asio::buffer(*buf), to,
+        [buf, to, success](boost::system::error_code ec, std::size_t) {
+            if (ec) {
+                auto addr = to.address().to_string();
+                warnf("send ROOM_LEFT to %s:%u failed: %s", addr.c_str(), to.port(), ec.message().c_str());
+            } else {
+                auto addr = to.address().to_string();
+                infof("ROOM_LEFT sent to %s:%u success=%d", addr.c_str(), to.port(), success);
+            }
+        });
+}
+
+void UdpServer::send_room_list(const udp::endpoint& to, const std::vector<RoomInfo>& rooms)
+{
+    NetHeader h{};
+    h.magic = kMagic;
+    h.version = kProtoVersion;
+    h.type = static_cast<uint8_t>(MsgType::ROOM_LIST);
+    h.seq = 0; h.ack = 0; h.ackBits = 0;
+
+    auto buf = std::make_shared<std::vector<uint8_t>>();
+    m_protocol.writeHeader(*buf, h);
+    RoomListBody body{};
+    
+    for (const auto& room : rooms) {
+        RoomInfoEntry entry{};
+        entry.roomId = room.roomId;
+        entry.roomName = room.name;
+        entry.currentPlayers = static_cast<uint8_t>(room.currentPlayers);
+        entry.maxPlayers = static_cast<uint8_t>(room.maxPlayers);
+        body.rooms.push_back(entry);
+    }
+    
+    m_protocol.writeRoomListBody(*buf, body);
+    
+    m_socket.async_send_to(boost::asio::buffer(*buf), to,
+        [buf, to, rooms](boost::system::error_code ec, std::size_t) {
+            if (ec) {
+                auto addr = to.address().to_string();
+                warnf("send ROOM_LIST to %s:%u failed: %s", addr.c_str(), to.port(), ec.message().c_str());
+            } else {
+                auto addr = to.address().to_string();
+                infof("ROOM_LIST sent to %s:%u with %zu rooms", addr.c_str(), to.port(), rooms.size());
+            }
+        });
+}
+
+void UdpServer::send_room_error(const udp::endpoint& to, uint8_t errorCode, const std::string& message)
+{
+    NetHeader h{};
+    h.magic = kMagic;
+    h.version = kProtoVersion;
+    h.type = static_cast<uint8_t>(MsgType::ROOM_ERROR);
+    h.seq = 0; h.ack = 0; h.ackBits = 0;
+
+    auto buf = std::make_shared<std::vector<uint8_t>>();
+    m_protocol.writeHeader(*buf, h);
+    RoomErrorBody body{};
+    body.errorCode = errorCode;
+    body.errorMessage = message;
+    m_protocol.writeRoomErrorBody(*buf, body);
+    
+    m_socket.async_send_to(boost::asio::buffer(*buf), to,
+        [buf, to, message](boost::system::error_code ec, std::size_t) {
+            if (ec) {
+                auto addr = to.address().to_string();
+                warnf("send ROOM_ERROR to %s:%u failed: %s", addr.c_str(), to.port(), ec.message().c_str());
+            } else {
+                auto addr = to.address().to_string();
+                infof("ROOM_ERROR sent to %s:%u: %s", addr.c_str(), to.port(), message.c_str());
+            }
+        });
+}
+
+void UdpServer::handle_create_room(std::shared_ptr<ClientSession> client, const CreateRoomBody& body)
+{
+    infof("CREATE_ROOM request from playerId=%u roomName='%s' maxPlayers=%u", 
+          client->playerId, body.roomName.c_str(), body.maxPlayers);
+    
+    if (body.roomName.empty()) {
+        send_room_error(client->endpoint, 1, "Room name cannot be empty");
+        return;
+    }
+    if (m_roomManager.roomExists(body.roomName)) {
+        send_room_error(client->endpoint, 2, "Room already exists");
+        return;
+    }
+    auto room = m_roomManager.createRoom(body.roomName, body.maxPlayers);
+    if (room) {
+        send_room_created(client->endpoint, room->getRoomId(), room->getName(), true);
+        handle_join_room(client, JoinRoomBody{body.roomName});
+    } else {
+        send_room_error(client->endpoint, 3, "Failed to create room");
+    }
+}
+
+void UdpServer::handle_join_room(std::shared_ptr<ClientSession> client, const JoinRoomBody& body)
+{
+    infof("JOIN_ROOM request from playerId=%u roomName='%s'", 
+          client->playerId, body.roomName.c_str());
+    if (body.roomName.empty()) {
+        send_room_error(client->endpoint, 1, "Room name cannot be empty");
+        return;
+    }
+    if (!m_roomManager.roomExists(body.roomName)) {
+        send_room_error(client->endpoint, 4, "Room not found");
+        return;
+    }
+    auto room = m_roomManager.getRoom(body.roomName);
+    if (!room) {
+        send_room_error(client->endpoint, 4, "Room not found");
+        return;
+    }
+    if (room->isFull()) {
+        send_room_error(client->endpoint, 5, "Room is full");
+        return;
+    }
+    if (m_roomManager.joinRoom(client, body.roomName)) {
+        send_room_joined(client->endpoint, room->getRoomId(), room->getName(), true, 
+                        static_cast<uint8_t>(room->getPlayerCount()));
+    } else {
+        send_room_error(client->endpoint, 6, "Failed to join room");
+    }
+}
+
+void UdpServer::handle_leave_room(std::shared_ptr<ClientSession> client)
+{
+    infof("LEAVE_ROOM request from playerId=%u", client->playerId);
+    
+    if (!client->currentRoom) {
+        send_room_error(client->endpoint, 7, "Not in any room");
+        return;
+    }
+    uint32_t roomId = client->currentRoom->getRoomId();
+    m_roomManager.leaveRoom(client);
+    send_room_left(client->endpoint, roomId, true);
+    m_roomManager.cleanup();
+}
+
+void UdpServer::handle_list_rooms(std::shared_ptr<ClientSession> client)
+{
+    infof("LIST_ROOMS request from playerId=%u", client->playerId);
+    
+    auto rooms = m_roomManager.listRooms();
+    send_room_list(client->endpoint, rooms);
+}
+
+void UdpServer::handle_message(std::shared_ptr<ClientSession> client, const MessageBody& body)
+{
+    infof("MESSAGE from playerId=%u: '%s'", client->playerId, body.message.c_str());
+    
+    if (!client->currentRoom) {
+        send_room_error(client->endpoint, 7, "Not in any room");
+        return;
+    }
+    NetHeader h{};
+    h.magic = kMagic;
+    h.version = kProtoVersion;
+    h.type = static_cast<uint8_t>(MsgType::ROOM_MESSAGE);
+    h.seq = 0; h.ack = 0; h.ackBits = 0;
+
+    std::vector<uint8_t> buf;
+    m_protocol.writeHeader(buf, h);
+    RoomMessageBody msgBody{};
+    msgBody.senderId = client->playerId;
+    msgBody.senderName = client->playerName;
+    msgBody.message = body.message;
+    m_protocol.writeRoomMessageBody(buf, msgBody);
+    client->currentRoom->broadcast(buf, client);
+}
+
 }


### PR DESCRIPTION
This pull request introduces a new networking layer to the client, enabling multiplayer room management and communication features. The main changes include the addition of a `NetworkClient` class and a protocol definition for client-server messages, as well as significant updates to the `GameManager` to support room-based multiplayer states and actions.

### Networking and Protocol Integration

* Added new files: `Client/include/net/NetworkClient.hpp` and `Client/include/net/Protocol.hpp`, implementing a UDP-based client and protocol for multiplayer room management, including message types and serialization/deserialization logic. [[1]](diffhunk://#diff-8a407680de982dff3b66b87ab4aac91ee351ba93fe7b803264de918861b91938R1-R88) [[2]](diffhunk://#diff-bc9408e39d1060b936c58f528e5e35d122989edda5d92ba63b87a8c5e94b4273R1-R158)
* Updated `Client/CMakeLists.txt` to include network source files for compilation.

### Game State and Room Management

* Expanded `GameManager` in `Client/include/GameTypes.hpp` with new states (`ROOM_LIST`, `IN_ROOM`), room-related member variables, and methods for initializing networking, connecting to server, creating/joining/leaving rooms, refreshing room list, and sending messages. [[1]](diffhunk://#diff-b516e2b50a7ae59ae0f5bc78209d83aaeb11ea01327d29dadd1b6ae6fd14bd78R23-R31) [[2]](diffhunk://#diff-b516e2b50a7ae59ae0f5bc78209d83aaeb11ea01327d29dadd1b6ae6fd14bd78R100-R108) [[3]](diffhunk://#diff-b516e2b50a7ae59ae0f5bc78209d83aaeb11ea01327d29dadd1b6ae6fd14bd78R139-R146) [[4]](diffhunk://#diff-b516e2b50a7ae59ae0f5bc78209d83aaeb11ea01327d29dadd1b6ae6fd14bd78R155-R177)
* Updated `GameManager` constructor to initialize new networking and room-related members.

### UI and Event Handling for Rooms

* Modified mouse click and render logic in `Client/src/GameTypes.cpp` to handle new room states, including joining rooms from a list and transitioning between menu, lobby, room list, and in-room states. [[1]](diffhunk://#diff-cb0ece12e065f1b9491cb58d58cd63a5ea35d938097889da3f69adf3cfa35abfR279-R280) [[2]](diffhunk://#diff-cb0ece12e065f1b9491cb58d58cd63a5ea35d938097889da3f69adf3cfa35abfL337-R347) [[3]](diffhunk://#diff-cb0ece12e065f1b9491cb58d58cd63a5ea35d938097889da3f69adf3cfa35abfR379-R407) [[4]](diffhunk://#diff-cb0ece12e065f1b9491cb58d58cd63a5ea35d938097889da3f69adf3cfa35abfR475-R482)

### Miscellaneous

* Removed unused code and comments in various places for clarity and maintainability. [[1]](diffhunk://#diff-cb0ece12e065f1b9491cb58d58cd63a5ea35d938097889da3f69adf3cfa35abfL744-L745) [[2]](diffhunk://#diff-cb0ece12e065f1b9491cb58d58cd63a5ea35d938097889da3f69adf3cfa35abfL759-L767)
* Updated stub implementation for `connectToServer` to always return true, pending integration with the new networking layer.